### PR TITLE
Made a small tweak to the oauth object reference in `set_page_token`

### DIFF
--- a/components/class-bsocial-facebook.php
+++ b/components/class-bsocial-facebook.php
@@ -266,7 +266,7 @@ class bSocial_Facebook
 
 		if ( $page && ! $post_as_user )
 		{
-			$this->oauth->service->token = $page->access_token;
+			$this->oauth()->service->token = $page->access_token;
 		} // END if
 
 		return $page;


### PR DESCRIPTION
Will this actually fix anything?  I don't know but it's in the page token stuff and it's the only place I referenced the object directly instead of the function.

Related:
https://github.com/misterbisson/bsocial/pull/30

Issue:
https://github.com/GigaOM/gigaom/issues/4769
