### PR TITLE
Add a filter to allow users to handle posts without a thumbnail.

### DIFF
--- a/components/class-bsocial-opengraph.php
+++ b/components/class-bsocial-opengraph.php
@@ -180,7 +180,8 @@ class bSocial_Opengraph
 					array()
 				);
 
-				$return['og:image'] = $this->get_thumbnail( $post->ID, 'large' );
+				$return['og:image'] = apply_filters( 'bsocial_opengraph_image', $this->get_thumbnail( $post->ID, 'large' ) );
+
 			}// END else
 			$return['og:title'] = empty( $post->post_title ) ? ' ' : wp_kses( get_the_title( $post->ID ), array() ) ;
 			$return['og:type']  = 'article';


### PR DESCRIPTION
Applies to https://github.com/GigaOM/gigaom/issues/6163

Adds a filter so we can decide how we want to handle the lack of a thumbnail and not let FB decide for us.
